### PR TITLE
Make S3File work as a context manager and add missing import 'datetime'

### DIFF
--- a/s3file.py
+++ b/s3file.py
@@ -11,17 +11,17 @@ def s3open(*args, **kwargs):
     return S3File(*args, **kwargs)
 
 class S3File(object):
-    
+
     def __init__(self, url, key=None, secret=None, expiration_days=0, private=False, content_type=None):
         from boto.s3.connection import S3Connection
         from boto.s3.key import Key
-        
+
         self.url = urlparse(url)
         self.expiration_days = expiration_days
         self.buffer = cStringIO.StringIO()
         self.private = private
         self.content_type = content_type or mimetypes.guess_type(self.url.path)[0]
-        
+
         bucket = self.url.netloc
         if bucket.endswith('.s3.amazonaws.com'):
             bucket = bucket[:-17]
@@ -30,9 +30,15 @@ class S3File(object):
         self.bucket = self.client.create_bucket(bucket)
         self.key = Key(self.bucket)
         self.key.key = self.url.path.lstrip("/")
-        
+
         self._remote_read()
-    
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
     def _remote_read(self):
         """ Read S3 contents into internal file buffer.
         """
@@ -40,65 +46,65 @@ class S3File(object):
         if self.key.exists():
             self.key.get_contents_to_file(self.buffer)
         self.buffer.seek(0)
-    
+
     def _remote_write(self):
         """ Write file contents to S3 from internal buffer.
         """
         self.truncate(self.tell())
-        
+
         headers = {
             "x-amz-acl":  "private" if self.private else "public-read"
         }
-        
+
         if self.content_type:
             headers["Content-Type"] = self.content_type
-        
+
         if self.expiration_days:
             now = datetime.datetime.utcnow()
             then = now + datetime.timedelta(self.expiration_days)
             headers["Expires"] = then.strftime("%a, %d %b %Y %H:%M:%S GMT")
             headers["Cache-Control"] = 'max-age=%d' % (self.expiration_days * 24 * 3600),
-        
+
         self.key.set_contents_from_file(self.buffer, headers=headers)
-    
+
     def close(self):
         """ Close the file and write contents to S3.
         """
         value = self.buffer.getvalue()
         self._remote_write()
         self.buffer.close()
-    
+
     # pass-through methods
-    
+
     def flush(self):
         self._remote_write()
-    
+
     def next(self):
         return self.buffer.next()
-    
+
     def read(self, size=-1):
         return self.buffer.read(size)
-    
+
     def readline(self, size=-1):
         return self.buffer.readline(size)
-    
+
     def readlines(self, sizehint=-1):
         return self.buffer.readlines(sizehint)
-    
+
     def xreadlines(self):
         return self.buffer.xreadlines()
-    
+
     def seek(self, offset, whence=os.SEEK_SET):
         self.buffer.seek(offset, whence)
-    
+
     def tell(self):
         return self.buffer.tell()
-    
+
     def truncate(self, size=None):
         self.buffer.truncate(size or self.tell())
-    
+
     def write(self, s):
         self.buffer.write(s)
-    
+
     def writelines(self, sequence):
         self.buffer.writelines(sequence)

--- a/s3file.py
+++ b/s3file.py
@@ -2,13 +2,16 @@ from urlparse import urlparse
 import cStringIO
 import mimetypes
 import os
+import datetime
 
 __version__ = '0.1'
+
 
 def s3open(*args, **kwargs):
     """ Convenience method for creating S3File object.
     """
     return S3File(*args, **kwargs)
+
 
 class S3File(object):
 

--- a/tests.py
+++ b/tests.py
@@ -7,73 +7,84 @@ import unittest
 
 LOREM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
 
+
 class TestS3File(unittest.TestCase):
-    
+
     def __init__(self, testname, key=None, secret=None):
         super(TestS3File, self).__init__(testname)
         self.key = key
         self.secret = secret
-    
-    def setUp(self):    
+
+    def setUp(self):
         conn = S3Connection(self.key, self.secret)
-        session_id = "%06d" % random.randint(0,999999)
+        session_id = "%06d" % random.randint(0, 999999)
         session_key = self.key.lower() if self.key else session_id
         self.bucket = conn.create_bucket("s3file_%s_%s" % (session_id, session_key))
-    
+
     def get_url(self, path):
         url_fmt = "http://%s.s3.amazonaws.com/%s"
         return url_fmt % (self.bucket.name, path.lstrip("/"))
-        
+
+    def test_context_manager(self):
+        path = 'test_write_cm.txt'
+
+        with s3open(self.get_url(path), key=self.key, secret=self.secret) as f:
+            f.write(LOREM)
+
+        k = Key(self.bucket, path)
+        self.assertEqual(k.get_contents_as_string(), LOREM)
+
     def test_write(self):
         path = 'test_write.txt'
-        
+
         # write using s3file
-        f = s3open(self.get_url(path))
+        f = s3open(self.get_url(path), key=self.key, secret=self.secret)
         f.write(LOREM)
         f.close()
-        
+
         # check contents using boto
         k = Key(self.bucket, path)
         self.assertEqual(k.get_contents_as_string(), LOREM)
-    
+
     def test_read(self):
         path = 'test_read.txt'
-        
+
         # write using boto
         k = Key(self.bucket, path)
         k.set_contents_from_string(LOREM)
-        
+
         # check contents using s3file
-        f = s3open(self.get_url(path))
+        f = s3open(self.get_url(path), key=self.key, secret=self.secret)
         self.assertEqual(f.read(), LOREM)
         f.close()
-    
+
     def test_tell(self):
         url = self.get_url('test_tell.txt')
-        f = s3open(url)
+        f = s3open(url, key=self.key, secret=self.secret)
         f.write(LOREM)
         f.close()
-        
-        f = s3open(url)
+
+        f = s3open(url, key=self.key, secret=self.secret)
         self.assertEqual(f.read(8), LOREM[:8])
         self.assertEqual(f.tell(), 8)
-        
+
     def tearDown(self):
         for key in self.bucket:
             key.delete()
         self.bucket.delete()
-    
+
 if __name__ == '__main__':
-    
+
     op = OptionParser()
     op.add_option("-k", "--key", dest="key", help="AWS key (optional if boto config exists)", metavar="KEY")
     op.add_option("-s", "--secret", dest="secret", help="AWS secret key (optional if boto config exists)", metavar="SECRET")
-    
+
     (options, args) = op.parse_args()
-    
+
     suite = unittest.TestSuite()
     suite.addTest(TestS3File("test_write", options.key, options.secret))
     suite.addTest(TestS3File("test_read", options.key, options.secret))
     suite.addTest(TestS3File("test_tell", options.key, options.secret))
+    suite.addTest(TestS3File("test_context_manager", options.key, options.secret))
 
     unittest.TextTestRunner().run(suite)


### PR DESCRIPTION
I also added a new unit test and made the unit tests work without a boto config file (using the passed in options)
