### PR TITLE
Read and write as required, name and closed properties added, xreadlines fixed - a significant increase in tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,11 @@ python-s3file
 
 Read and write files to S3 using a file-like object. Refer to S3 buckets and keys using full URLs.
 
+The underlying mechanism is a lazy read and write using ``cStringIO`` as the file emulation. This is an in memory buffer so is not suitable for large files (larger than your memory).
+
+As S3 only supports reads and writes of the whole key, the S3 key will be read in its entirety and written on ``close``. Starting from release 1.2 this read and write are deferred until required and the key is only read from if the file is read from or written within and only updated if a write operation has been carried out on the buffer contents.
+
+
 More tests and docs are needed.
 
 Requirements
@@ -25,7 +30,7 @@ Basic usage::
 ``with`` statement::
 
 	with s3open(path) as remote_file:
-	    remote_file.write("blah blah blah")
+	    remote_file.read("blah blah blah")
 
 S3 authentication key and secret may be passed into the ``s3open`` method or stored in the `boto config file <http://code.google.com/p/boto/wiki/BotoConfig>`_.::
 

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Basic usage::
 ``with`` statement::
 
 	with s3open(path) as remote_file:
-	    remote_file.read("blah blah blah")
+	    remote_file.write("blah blah blah")
 
 S3 authentication key and secret may be passed into the ``s3open`` method or stored in the `boto config file <http://code.google.com/p/boto/wiki/BotoConfig>`_.::
 

--- a/s3file.py
+++ b/s3file.py
@@ -4,8 +4,7 @@ import mimetypes
 import os
 import datetime
 
-__version__ = '1.1'
-
+__version__ = '1.2'
 
 def s3open(*args, **kwargs):
     """ Convenience method for creating S3File object.
@@ -22,7 +21,11 @@ class S3File(object):
         self.url = urlparse(url)
         self.expiration_days = expiration_days
         self.buffer = cStringIO.StringIO()
+
         self.private = private
+        self.closed = False
+        self._readreq = True
+        self._writereq = False
         self.content_type = content_type or mimetypes.guess_type(self.url.path)[0]
 
         bucket = self.url.netloc
@@ -31,6 +34,8 @@ class S3File(object):
 
         self.client = S3Connection(key, secret)
 
+        self.name = "s3://" + bucket + self.url.path
+
         if create:
             self.bucket = self.client.create_bucket(bucket)
         else:
@@ -38,8 +43,7 @@ class S3File(object):
 
         self.key = Key(self.bucket)
         self.key.key = self.url.path.lstrip("/")
-
-        self._remote_read()
+        self.buffer.truncate(0)
 
     def __enter__(self):
         return self
@@ -49,37 +53,42 @@ class S3File(object):
 
     def _remote_read(self):
         """ Read S3 contents into internal file buffer.
+            Once only
         """
-        self.buffer.truncate(0)
-        if self.key.exists():
-            self.key.get_contents_to_file(self.buffer)
-        self.buffer.seek(0)
+        if self._readreq:
+                self.buffer.truncate(0)
+                if self.key.exists():
+                    self.key.get_contents_to_file(self.buffer)
+                self.buffer.seek(0)
+                self._readreq = False
 
     def _remote_write(self):
         """ Write file contents to S3 from internal buffer.
         """
-        self.truncate(self.tell())
+        if self._writereq:
+            self.truncate(self.tell())
 
-        headers = {
-            "x-amz-acl":  "private" if self.private else "public-read"
-        }
+            headers = {
+                "x-amz-acl":  "private" if self.private else "public-read"
+            }
 
-        if self.content_type:
-            headers["Content-Type"] = self.content_type
+            if self.content_type:
+                headers["Content-Type"] = self.content_type
 
-        if self.expiration_days:
-            now = datetime.datetime.utcnow()
-            then = now + datetime.timedelta(self.expiration_days)
-            headers["Expires"] = then.strftime("%a, %d %b %Y %H:%M:%S GMT")
-            headers["Cache-Control"] = 'max-age=%d' % (self.expiration_days * 24 * 3600,)
+            if self.expiration_days:
+                now = datetime.datetime.utcnow()
+                then = now + datetime.timedelta(self.expiration_days)
+                headers["Expires"] = then.strftime("%a, %d %b %Y %H:%M:%S GMT")
+                headers["Cache-Control"] = 'max-age=%d' % (self.expiration_days * 24 * 3600,)
 
-        self.key.set_contents_from_file(self.buffer, headers=headers, rewind=True)
+            self.key.set_contents_from_file(self.buffer, headers=headers, rewind=True)
 
     def close(self):
         """ Close the file and write contents to S3.
         """
         self._remote_write()
         self.buffer.close()
+        self.closed = True
 
     # pass-through methods
 
@@ -87,31 +96,44 @@ class S3File(object):
         self._remote_write()
 
     def next(self):
+        self._remote_read()
         return self.buffer.next()
 
     def read(self, size=-1):
+        self._remote_read()
         return self.buffer.read(size)
 
     def readline(self, size=-1):
+        self._remote_read()
         return self.buffer.readline(size)
 
     def readlines(self, sizehint=-1):
+        self._remote_read()
         return self.buffer.readlines(sizehint)
 
     def xreadlines(self):
-        return self.buffer.xreadlines()
+        self._remote_read()
+        return self.buffer
 
     def seek(self, offset, whence=os.SEEK_SET):
         self.buffer.seek(offset, whence)
+        # if it looks like we are moving in the file and we have not written
+        # anything then we probably should read the contents
+        if self.tell() != 0 and self._readreq and not self._writereq:
+                self._remote_read()
+                self.buffer.seek(offset, whence)
 
     def tell(self):
         return self.buffer.tell()
 
     def truncate(self, size=None):
+        self._writereq = True
         self.buffer.truncate(size or self.tell())
 
     def write(self, s):
+        self._writereq = True
         self.buffer.write(s)
 
     def writelines(self, sequence):
+        self._writereq = True
         self.buffer.writelines(sequence)

--- a/tests.py
+++ b/tests.py
@@ -68,10 +68,183 @@ class TestS3File(unittest.TestCase):
         self.assertEqual(f.read(8), LOREM[:8])
         self.assertEqual(f.tell(), 8)
 
+    def lorem_est(self):
+	lor = LOREM + "\n"
+	lines = [lor, lor[1:]+lor[:1], lor[2:]+lor[:2], lor[3:]+lor[:3],
+		lor[4:]+lor[:4], lor[5:]+lor[:5], lor[6:]+lor[:6]]
+	return lines
+
+    def test_readlines(self):
+	path = 'test_readlines.txt'
+	url = self.get_url(path)
+	lines = self.lorem_est()
+	res = "".join(lines)
+        k = Key(self.bucket, path)
+        k.set_contents_from_string(res)
+        f = s3open(url, key=self.key, secret=self.secret)
+	rlines = f.readlines()
+	rres = "".join(rlines)
+	f.close()
+        self.assertEqual(res, rres)
+
+    def test_writelines(self):
+	path = "test_writelines.txt"
+	url = self.get_url(path)
+        f = s3open(url, key=self.key, secret=self.secret)
+	lines = self.lorem_est()
+	res = "".join(lines)
+	f.writelines(lines)
+	f.close()
+        k = Key(self.bucket, path)
+        self.assertEqual(k.get_contents_as_string(), res)
+
+    def test_readline(self):
+	path = 'test_readline.txt'
+	url = self.get_url(path)
+	lines = self.lorem_est()
+	res = "".join(lines)
+        k = Key(self.bucket, path)
+        k.set_contents_from_string(res)
+        f = s3open(url, key=self.key, secret=self.secret)
+	rline = f.readline()
+	f.close()
+        self.assertEqual(rline, LOREM + '\n')
+
+    def test_closed(self):
+	path = 'test_closed.txt'
+	url = self.get_url(path)
+        f = s3open(url, key=self.key, secret=self.secret)
+	self.assertEqual(False, f.closed)
+	f.close()
+	self.assertEqual(True, f.closed)
+
+    def test_name(self):
+	path = 'test_name.txt'
+	url = self.get_url(path)
+        f = s3open(url, key=self.key, secret=self.secret)
+	self.assertEqual("s3://" + self.bucket.name + "/" + path, f.name)
+	f.close()
+
+    def test_flush(self):
+	path = 'test_flush.txt'
+	url = self.get_url(path)
+	fl = LOREM + "\n" + LOREM + "\n"
+	fl2 = fl + fl
+        f = s3open(url, key=self.key, secret=self.secret)
+	f.write(fl)
+	f.flush()
+        k = Key(self.bucket, path)
+        self.assertEqual(k.get_contents_as_string(), fl)
+	f.write(fl)
+	f.close()
+        self.assertEqual(k.get_contents_as_string(), fl2)
+
+    def test_xreadlines(self):
+	path = 'test_xreadlines.txt'
+	url = self.get_url(path)
+	lines = self.lorem_est()
+	res = "".join(lines)
+        k = Key(self.bucket, path)
+        k.set_contents_from_string(res)
+        f = s3open(url, key=self.key, secret=self.secret)
+	rres = ""
+	for lin in f.xreadlines():
+	    rres += lin
+	f.close()
+        self.assertEqual(res, rres)
+
+    def test_seek(self):
+	# needs start, relative, end
+	path = 'test_seek.txt'
+	url = self.get_url(path)
+	lines = self.lorem_est()
+	res = "".join(lines)
+        k = Key(self.bucket, path)
+        k.set_contents_from_string(res)
+        f = s3open(url, key=self.key, secret=self.secret)
+	f.seek(2,0)
+	self.assertEqual(f.read(8), res[2:10])
+	f.seek(1)
+	self.assertEqual(f.read(8), res[1:9])
+	f.seek(-1,1)
+	self.assertEqual(f.read(9), res[8:17])
+	f.seek(-10,2)
+	self.assertEqual(f.read(10), res[-10:])
+	f.close()
+
+    def test_truncate(self):
+	path = 'test_truncate.txt'
+	url = self.get_url(path)
+	lines = self.lorem_est()
+	res = "".join(lines)
+        k = Key(self.bucket, path)
+        k.set_contents_from_string(res)
+        f = s3open(url, key=self.key, secret=self.secret)
+	dummy = f.read() # not convinced we should do this but down to the trucate in the write
+	f.truncate(3)
+	f.close()
+
+        t = s3open(url, key=self.key, secret=self.secret)
+	self.assertEqual(t.read(), res[:3])
+	t.seek(1,0)
+	t.truncate()
+	t.close()
+
+        f = s3open(url, key=self.key, secret=self.secret)
+	self.assertEqual(f.read(), res[:1])
+	f.close()
+
+    def _bin_str(self):
+	bs = ""
+	for i in xrange(0,256):
+		bs += chr(i)
+	return bs
+
+    def test_binary_write(self):
+        path = 'test_binary_write.txt'
+	bs = self._bin_str()
+        f = s3open(self.get_url(path), key=self.key, secret=self.secret)
+        f.write(bs)
+        f.close()
+        k = Key(self.bucket, path)
+        self.assertEqual(k.get_contents_as_string(), bs)
+
+    def test_large_binary_write(self):
+        path = 'test_large_binary_write.txt'
+	bs = self._bin_str()
+	for i in  xrange(0, 10):
+		bs += bs
+        f = s3open(self.get_url(path), key=self.key, secret=self.secret)
+        f.write(bs)
+        f.close()
+        k = Key(self.bucket, path)
+        self.assertEqual(k.get_contents_as_string(), bs)
+
+    def test_binary_read(self):
+        path = 'test_binary_read.txt'
+	bs = self._bin_str()
+        k = Key(self.bucket, path)
+        k.set_contents_from_string(bs)
+        f = s3open(self.get_url(path), key=self.key, secret=self.secret)
+        self.assertEqual(f.read(), bs)
+        f.close()
+
+    def test_large_binary_read(self):
+        path = 'test_large_binary_read.txt'
+	bs = self._bin_str()
+	for i in  xrange(0, 10):
+		bs += bs
+        k = Key(self.bucket, path)
+        k.set_contents_from_string(bs)
+        f = s3open(self.get_url(path), key=self.key, secret=self.secret)
+        self.assertEqual(f.read(), bs)
+        f.close()
+
     def tearDown(self):
         for key in self.bucket:
             key.delete()
         self.bucket.delete()
+
 
 if __name__ == '__main__':
 
@@ -86,5 +259,18 @@ if __name__ == '__main__':
     suite.addTest(TestS3File("test_read", options.key, options.secret))
     suite.addTest(TestS3File("test_tell", options.key, options.secret))
     suite.addTest(TestS3File("test_context_manager", options.key, options.secret))
+    suite.addTest(TestS3File("test_readlines", options.key, options.secret))
+    suite.addTest(TestS3File("test_writelines", options.key, options.secret))
+    suite.addTest(TestS3File("test_readline", options.key, options.secret))
+    suite.addTest(TestS3File("test_closed", options.key, options.secret))
+    suite.addTest(TestS3File("test_name", options.key, options.secret))
+    suite.addTest(TestS3File("test_flush", options.key, options.secret))
+    suite.addTest(TestS3File("test_xreadlines", options.key, options.secret))
+    suite.addTest(TestS3File("test_seek", options.key, options.secret))
+    suite.addTest(TestS3File("test_truncate", options.key, options.secret))
+    suite.addTest(TestS3File("test_binary_write", options.key, options.secret))
+    suite.addTest(TestS3File("test_large_binary_write", options.key, options.secret))
+    suite.addTest(TestS3File("test_binary_read", options.key, options.secret))
+    suite.addTest(TestS3File("test_large_binary_read", options.key, options.secret))
 
     unittest.TextTestRunner().run(suite)


### PR DESCRIPTION
I am putting python-s3file into ftp-s3 so that that has write capabilities. It needs a couple of the file like properties. I am overwriting some fairly large files so I have made the read and write lazy so that I am not writing data that has not changed and not fetching data that I intend to overwrite.

Hope you find this useful.
