### PR TITLE
add standard file mode param, add content_encoding

### DIFF
--- a/s3file.py
+++ b/s3file.py
@@ -14,7 +14,7 @@ def s3open(*args, **kwargs):
 
 class S3File(object):
 
-    def __init__(self, url,mode, key=None, secret=None, expiration_days=0, private=False, content_type=None,content_encoding=None):
+    def __init__(self, url,mode='r', key=None, secret=None, expiration_days=0, private=False, content_type=None,content_encoding=None):
         from boto.s3.connection import S3Connection
         from boto.s3.key import Key
 


### PR DESCRIPTION
This PR adds:

1) Standard python file mode param, and doesn't try to create bucket by default (also non-standard file behavior)

2) Adds content_encoding param to handle compressed or otherwise encoded files. 
